### PR TITLE
Add AsyncStorage repositories

### DIFF
--- a/client/src/storage/storage.test.ts
+++ b/client/src/storage/storage.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Meal, Product } from '../models/types';
+import { loadMeals, loadProducts, saveMeals, saveProducts } from './storage';
+
+const storageStore = new Map<string, string>();
+
+vi.mock('@react-native-async-storage/async-storage', () => {
+  return {
+    default: {
+      getItem: vi.fn(async (key: string) => storageStore.get(key) ?? null),
+      setItem: vi.fn(async (key: string, value: string) => {
+        storageStore.set(key, value);
+      }),
+      removeItem: vi.fn(async (key: string) => {
+        storageStore.delete(key);
+      }),
+      clear: vi.fn(async () => {
+        storageStore.clear();
+      }),
+    },
+  };
+});
+
+describe('storage repositories', () => {
+  beforeEach(() => {
+    storageStore.clear();
+  });
+
+  const sampleProducts: Product[] = [
+    {
+      id: 'chicken',
+      name: 'Chicken breast',
+      caloriesPer100g: 165,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    },
+    {
+      id: 'rice',
+      name: 'Cooked rice',
+      caloriesPer100g: 130,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    },
+  ];
+
+  const sampleMeals: Meal[] = [
+    {
+      id: 'meal-1',
+      name: 'Lunch',
+      items: [
+        { productId: 'chicken', grams: 150 },
+        { productId: 'rice', grams: 200 },
+      ],
+      totalCalories: 507.5,
+      createdAt: '2025-01-01T12:00:00.000Z',
+      updatedAt: '2025-01-01T12:00:00.000Z',
+    },
+  ];
+
+  it('returns empty arrays when nothing is stored', async () => {
+    await expect(loadProducts()).resolves.toEqual([]);
+    await expect(loadMeals()).resolves.toEqual([]);
+  });
+
+  it('saves and loads products via AsyncStorage', async () => {
+    await saveProducts(sampleProducts);
+    await expect(loadProducts()).resolves.toEqual(sampleProducts);
+  });
+
+  it('saves and loads meals via AsyncStorage', async () => {
+    await saveMeals(sampleMeals);
+    await expect(loadMeals()).resolves.toEqual(sampleMeals);
+  });
+});
+

--- a/client/src/storage/storage.ts
+++ b/client/src/storage/storage.ts
@@ -1,1 +1,59 @@
-﻿export const storage = {};
+﻿import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { Meal, Product } from '../models/types';
+
+const STORAGE_PREFIX = '@countOnMe';
+const STORAGE_VERSION = 'v1';
+
+const STORAGE_KEYS = {
+  products: `${STORAGE_PREFIX}/products/${STORAGE_VERSION}`,
+  meals: `${STORAGE_PREFIX}/meals/${STORAGE_VERSION}`,
+} as const;
+
+const parseCollection = <T>(rawValue: string | null): T[] => {
+  if (!rawValue) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const loadCollection = async <T>(key: string): Promise<T[]> => {
+  try {
+    const rawValue = await AsyncStorage.getItem(key);
+    return parseCollection<T>(rawValue);
+  } catch (error) {
+    console.error(`Failed to load data for ${key}`, error);
+    return [];
+  }
+};
+
+const saveCollection = async <T>(key: string, data: T[]): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(key, JSON.stringify(data));
+  } catch (error) {
+    console.error(`Failed to save data for ${key}`, error);
+    throw error;
+  }
+};
+
+export const loadProducts = async (): Promise<Product[]> => {
+  return loadCollection<Product>(STORAGE_KEYS.products);
+};
+
+export const saveProducts = async (products: Product[]): Promise<void> => {
+  await saveCollection<Product>(STORAGE_KEYS.products, products);
+};
+
+export const loadMeals = async (): Promise<Meal[]> => {
+  return loadCollection<Meal>(STORAGE_KEYS.meals);
+};
+
+export const saveMeals = async (meals: Meal[]): Promise<void> => {
+  await saveCollection<Meal>(STORAGE_KEYS.meals, meals);
+};


### PR DESCRIPTION
## Summary
- add versioned AsyncStorage helpers for products and meals
- expose load/save functions that default to [] and stringify safely
- add Vitest coverage to ensure round-trips and empty states behave

## Testing
- pnpm test
- pnpm tsc --noEmit

Closes #5