### PR TITLE
Implement products list screen

### DIFF
--- a/client/src/components/ProductListItem.tsx
+++ b/client/src/components/ProductListItem.tsx
@@ -6,15 +6,30 @@ import { Product } from '../models/types';
 interface ProductListItemProps {
   product: Product;
   onPress?: () => void;
+  onDelete?: () => void;
 }
 
-const ProductListItem = ({ product, onPress }: ProductListItemProps) => {
+const ProductListItem = ({ product, onPress, onDelete }: ProductListItemProps) => {
   return (
-    <Pressable onPress={onPress} style={({ pressed }) => [styles.container, pressed && styles.pressed]}>
-      <View>
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={({ pressed }) => [styles.container, pressed && styles.pressed]}
+    >
+      <View style={styles.info}>
         <Text style={styles.name}>{product.name}</Text>
         <Text style={styles.meta}>{product.caloriesPer100g} kcal / 100g</Text>
       </View>
+      {onDelete ? (
+        <Pressable
+          accessibilityRole="button"
+          hitSlop={8}
+          onPress={onDelete}
+          style={({ pressed }) => [styles.deleteButton, pressed && styles.pressedDelete]}
+        >
+          <Text style={styles.deleteText}>Delete</Text>
+        </Pressable>
+      ) : null}
     </Pressable>
   );
 };
@@ -23,11 +38,18 @@ export default ProductListItem;
 
 const styles = StyleSheet.create({
   container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     padding: 16,
     borderRadius: 12,
     borderWidth: 1,
     borderColor: '#eee',
     backgroundColor: '#fafafa',
+  },
+  info: {
+    flex: 1,
+    marginRight: 12,
   },
   pressed: {
     opacity: 0.6,
@@ -40,5 +62,20 @@ const styles = StyleSheet.create({
   meta: {
     fontSize: 14,
     color: '#555',
+  },
+  deleteButton: {
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#fee2e2',
+    backgroundColor: '#fee2e2',
+  },
+  pressedDelete: {
+    opacity: 0.5,
+  },
+  deleteText: {
+    color: '#b91c1c',
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
## Summary
- connect ProductsListScreen to the real useProducts hook with refresh, delete, and loading states
- add a richer UI with empty state messaging and per-row delete actions
- extend ProductListItem so rows expose edit (tap) and delete affordances

## Testing
- pnpm test
- pnpm tsc --noEmit

Closes #7